### PR TITLE
Jet Veto Map Selector

### DIFF
--- a/topsf/config/run2/config_sf.py
+++ b/topsf/config/run2/config_sf.py
@@ -1114,11 +1114,14 @@ def add_config(
     if year != 2017:
         raise NotImplementedError("TODO: external files only implemented for 2017")
 
-    json_mirror = "/afs/cern.ch/user/d/dsavoiu/public/mirrors/jsonpog-integration-a81953b1"
+    json_mirror = "/afs/cern.ch/user/j/jmatthie/public/mirrors/jsonpog-integration-49ddc547"
     local_repo = "/nfs/dust/cms/user/matthiej/topsf"  # TODO: avoid hardcoding path
     cfg.x.external_files = DotDict.wrap({
         # jet energy corrections
         "jet_jerc": (f"{json_mirror}/POG/JME/{year}_UL/jet_jerc.json.gz", "v1"),  # noqa
+
+        # jet veto map
+        "jet_veto_map": (f"{json_mirror}/POG/JME/{year}_UL/jetvetomaps.json.gz", "v1"),  # noqa
 
         # btag scale factors
         "btag_sf_corr": (f"{json_mirror}/POG/BTV/{year}_UL/btagging.json.gz", "v1"),  # noqa

--- a/topsf/config/run2/config_wp.py
+++ b/topsf/config/run2/config_wp.py
@@ -618,13 +618,16 @@ def add_config(
     sources = {
         "cert": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV",
         "local_repo": "/nfs/dust/cms/user/matthiej/topsf",  # TODO: avoid hardcoding path
-        "json_mirror": "/afs/cern.ch/user/d/dsavoiu/public/mirrors/jsonpog-integration-a81953b1",
+        "json_mirror": "/afs/cern.ch/user/j/jmatthie/public/mirrors/jsonpog-integration-49ddc547",
         "jet": "/afs/cern.ch/user/d/dsavoiu/public/mirrors/cms-jet-JSON_Format-54860a23",
         "normtag": "/afs/cern.ch/user/d/dsavoiu/public/lumi/snapshot_2023-11-10_1610Z",
     }
     cfg.x.external_files = DotDict.wrap({
         # jet energy corrections
         "jet_jerc": (f"{sources['json_mirror']}/POG/JME/{year}_UL/jet_jerc.json.gz", "v1"),  # noqa
+
+        # jet veto map
+        "jet_veto_map": (f"{sources['json_mirror']}/POG/JME/{year}_UL/jetvetomaps.json.gz", "v1"),  # noqa
 
         # btag scale factors
         "btag_sf_corr": (f"{sources['json_mirror']}/POG/BTV/{year}_UL/btagging.json.gz", "v1"),  # noqa

--- a/topsf/config/run3/config_sf.py
+++ b/topsf/config/run3/config_sf.py
@@ -1132,6 +1132,9 @@ def add_config(
         # jet energy correction
         "jet_jerc": (f"{json_mirror}/POG/JME/{corr_tag}/jet_jerc.json.gz", "v1"),
 
+        # jet veto map
+        "jet_veto_map": (f"{json_mirror}/POG/JME/{corr_tag}/jetvetomaps.json.gz", "v1"),
+
         # electron scale factors
         "electron_sf": (f"{json_mirror}/POG/EGM/{corr_tag}/electron.json.gz", "v1"),
 

--- a/topsf/config/run3/config_wp.py
+++ b/topsf/config/run3/config_wp.py
@@ -744,6 +744,9 @@ def add_config(
         # jet energy correction
         "jet_jerc": (f"{json_mirror}/POG/JME/{corr_tag}/jet_jerc.json.gz", "v1"),
 
+        # jet veto map
+        "jet_veto_map": (f"{json_mirror}/POG/JME/{corr_tag}/jetvetomaps.json.gz", "v1"),
+
         # electron scale factors
         "electron_sf": (f"{json_mirror}/POG/EGM/{corr_tag}/electron.json.gz", "v1"),
 

--- a/topsf/selection/default.py
+++ b/topsf/selection/default.py
@@ -14,6 +14,7 @@ from columnflow.columnar_util import optional_column as optional
 from columnflow.selection import Selector, SelectionResult, selector
 from columnflow.selection.cms.met_filters import met_filters
 from columnflow.selection.cms.json_filter import json_filter
+from columnflow.selection.cms.jets import jet_veto_map
 
 from columnflow.production.cms.mc_weight import mc_weight
 from columnflow.production.util import attach_coffea_behavior
@@ -109,6 +110,7 @@ def increment_stats(
         lepton_selection,
         met_selection,
         w_lep_selection,
+        jet_veto_map,
         jet_selection,
         bjet_lepton_selection,
         jet_lepton_2d_selection,
@@ -125,6 +127,7 @@ def increment_stats(
         lepton_selection,
         met_selection,
         w_lep_selection,
+        jet_veto_map,
         jet_selection,
         bjet_lepton_selection,
         jet_lepton_2d_selection,
@@ -184,6 +187,10 @@ def default(
     # w_lep selection
     events, w_lep_results = self[w_lep_selection](events, **kwargs)
     results += w_lep_results
+
+    # apply jet veto map
+    events, jet_veto_results = self[jet_veto_map](events, **kwargs)
+    results += jet_veto_results
 
     # combined event selection after all steps
     event_sel = reduce(and_, results.steps.values())

--- a/topsf/selection/wp.py
+++ b/topsf/selection/wp.py
@@ -12,6 +12,7 @@ from columnflow.util import maybe_import
 
 from columnflow.selection import Selector, SelectionResult, selector
 from columnflow.selection.cms.met_filters import met_filters
+from columnflow.selection.cms.jets import jet_veto_map
 
 from columnflow.production.util import attach_coffea_behavior
 from columnflow.production.processes import process_ids
@@ -124,6 +125,7 @@ def wp_fatjet_selection_init(self: Selector) -> None:
         process_ids,
         met_filters,
         wp_fatjet_selection,
+        jet_veto_map,
         increment_stats,
     },
     produces={
@@ -131,6 +133,7 @@ def wp_fatjet_selection_init(self: Selector) -> None:
         process_ids,
         met_filters,
         wp_fatjet_selection,
+        jet_veto_map,
         increment_stats,
     },
     exposed=True,
@@ -159,6 +162,10 @@ def wp(
         **kwargs,
     )
     results += wp_fatjet_results
+
+    # apply jet veto map
+    events, jet_veto_results = self[jet_veto_map](events, **kwargs)
+    results += jet_veto_results
 
     # combined event selection after all steps
     event_sel = reduce(and_, results.steps.values())


### PR DESCRIPTION
This PR adds the columnflow ```jet_veto_map``` selector to the selection chain of both WP and SF analyses using the POG provided json files and applying the veto. 