### PR TITLE
Updating columnflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ data
 .data
 .law
 .setups
+workflow_scripts/*
+luigi-server*
+examples/009_combine/cf_shapes*
+examples/009_combine/task_dirs*
+zzz_copy_space/*

--- a/law.cfg
+++ b/law.cfg
@@ -91,31 +91,31 @@ lfn_sources: local_desy_dcache, wlcg_fs_infn_redirector, wlcg_fs_global_redirect
 # for local targets : "local[, LOCAL_FS_NAME or STORE_PATH]"
 # for remote targets: "wlcg[, WLCG_FS_NAME]"
 # (when WLCG_FS_NAME is empty, the tasks' "default_wlcg_fs" attribute is used)
-cf.BundleRepo: local
-cf.BundleSoftware: local
-cf.BundleBashSandbox: local
-cf.BundleCMSSWSandbox: local
-cf.BundleExternalFiles: local
+task_cf.BundleRepo: local
+task_cf.BundleSoftware: local
+task_cf.BundleBashSandbox: local
+task_cf.BundleCMSSWSandbox: local
+task_cf.BundleExternalFiles: local
 # GetDatasetLFNs requires a Grid certificate -> use a common space to store the output
-cf.GetDatasetLFNs: local
-cf.CalibrateEvents: wlcg
-cf.SelectEvents: wlcg
-cf.CreateCutflowHistograms: wlcg
-cf.PlotCutflow: local
-cf.PlotCutflowVariables: local
-cf.ReduceEvents: wlcg
-cf.MergeReducedEvents: wlcg
-cf.ProduceColumns: wlcg
-cf.PrepareMLEvents: wlcg
-cf.MergeMLEvents: wlcg
-cf.MLTraining: wlcg
-cf.MLEvaluation: wlcg
-cf.CreateHistograms: local
-cf.MergeHistograms: local
-cf.MergeShiftedHistograms: local
-cf.PlotVariables1D: local
-cf.PlotShiftedVariables: local
-cf.CreateDatacards: local
+task_cf.GetDatasetLFNs: local
+task_cf.CalibrateEvents: wlcg
+task_cf.SelectEvents: wlcg
+task_cf.CreateCutflowHistograms: wlcg
+task_cf.PlotCutflow: local
+task_cf.PlotCutflowVariables: local
+task_cf.ReduceEvents: wlcg
+task_cf.MergeReducedEvents: wlcg
+task_cf.ProduceColumns: wlcg
+task_cf.PrepareMLEvents: wlcg
+task_cf.MergeMLEvents: wlcg
+task_cf.MLTraining: wlcg
+task_cf.MLEvaluation: wlcg
+task_cf.CreateHistograms: local
+task_cf.MergeHistograms: local
+task_cf.MergeShiftedHistograms: local
+task_cf.PlotVariables1D: local
+task_cf.PlotShiftedVariables: local
+task_cf.CreateDatacards: local
 
 
 [job]

--- a/law.nocert.cfg
+++ b/law.nocert.cfg
@@ -22,28 +22,28 @@ lfn_sources: local_desy_dcache
 # output locations per task family
 # for local targets : "local[, LOCAL_FS_NAME or STORE_PATH]"
 # for remote targets: "wlcg[, WLCG_FS_NAME]"
-cf.BundleRepo: local
-cf.BundleSoftware: local
-cf.BundleBashSandbox: local
-cf.BundleCMSSWSandbox: local
-cf.BundleExternalFiles: local
+task_cf.BundleRepo: local
+task_cf.BundleSoftware: local
+task_cf.BundleBashSandbox: local
+task_cf.BundleCMSSWSandbox: local
+task_cf.BundleExternalFiles: local
 # GetDatasetLFNs requires a Grid certificate -> use a common space to store the output
-cf.GetDatasetLFNs: local, /data/dust/user/dsavoiu/store/mttbar/data
-cf.CalibrateEvents: local
-cf.SelectEvents: local
-cf.CreateCutflowHistograms: local
-cf.PlotCutflow: local
-cf.PlotCutflowVariables: local
-cf.ReduceEvents: local
-cf.MergeReducedEvents: local
-cf.ProduceColumns: local
-cf.PrepareMLEvents: local
-cf.MergeMLEvents: local
-cf.MLTraining: local
-cf.MLEvaluation: local
-cf.CreateHistograms: local
-cf.MergeHistograms: local
-cf.MergeShiftedHistograms: local
-cf.PlotVariables: local
-cf.PlotShiftedVariables: local
-cf.CreateDatacards: local
+task_cf.GetDatasetLFNs: local, /data/dust/user/dsavoiu/store/mttbar/data
+task_cf.CalibrateEvents: local
+task_cf.SelectEvents: local
+task_cf.CreateCutflowHistograms: local
+task_cf.PlotCutflow: local
+task_cf.PlotCutflowVariables: local
+task_cf.ReduceEvents: local
+task_cf.MergeReducedEvents: local
+task_cf.ProduceColumns: local
+task_cf.PrepareMLEvents: local
+task_cf.MergeMLEvents: local
+task_cf.MLTraining: local
+task_cf.MLEvaluation: local
+task_cf.CreateHistograms: local
+task_cf.MergeHistograms: local
+task_cf.MergeShiftedHistograms: local
+task_cf.PlotVariables: local
+task_cf.PlotShiftedVariables: local
+task_cf.CreateDatacards: local

--- a/topsf/calibration/default.py
+++ b/topsf/calibration/default.py
@@ -13,7 +13,11 @@ from columnflow.production.cms.seeds import deterministic_seeds
 from columnflow.util import maybe_import
 from columnflow.columnar_util import set_ak_column
 
-from topsf.calibration.jets import jet_lepton_cleaner, jec_subjets, jer_subjets
+from topsf.calibration.jets import (
+    jet_lepton_cleaner,
+    jec_subjets,
+    # jer_subjets
+)
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -54,7 +58,8 @@ def default(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     events = self[deterministic_seeds](events, **kwargs)
 
     # fake subjet area column by setting it to an array with the same structure as the subjet pt column containing 0.5
-    # (needed to be able to use same code as for top-level AK4/AK8 jets, as the producer formally requires an `area` column, despite not actually using it)
+    # (needed to be able to use same code as for top-level AK4/AK8 jets, as the producer formally requires an `area`
+    # column, despite not actually using it)
     events = set_ak_column_f32(events, "SubJet.area", 0.5 * ak.ones_like(events.SubJet.pt))
 
     events = self[jec_subjets](events, **kwargs)

--- a/topsf/config/run2/config_sf.py
+++ b/topsf/config/run2/config_sf.py
@@ -383,6 +383,7 @@ def add_config(
     cfg.x.default_selector = "default"
     cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
+    cfg.x.default_hist_producer = "cf_default"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = "default"  # "uhh2"
     cfg.x.default_categories = ("incl",)

--- a/topsf/config/run2/config_sf.py
+++ b/topsf/config/run2/config_sf.py
@@ -559,8 +559,9 @@ def add_config(
     # As of 02.05.2024, it is required to pass a weight_producer for tasks creating histograms.
     # You can add a 'default_weight_producer' to your config or directly add the weight_producer
     # on command line via the '--weight_producer' parameter. To reproduce results from before this date,
-    # you can use the 'all_weights' weight_producer defined in columnflow.weight.all_weights:
-    cfg.x.default_weight_producer = "all_weights"
+    # you can use the 'all_weights' weight_producer defined in columnflow.weight.all_weights.
+    # With cf 0.3.x, the 'weight_producer' has been renamed to 'hist_producer'.
+    cfg.x.default_hist_producer = "all_weights"
 
     # custom labels for selector steps
     cfg.x.selector_step_labels = {}

--- a/topsf/config/run2/config_sf.py
+++ b/topsf/config/run2/config_sf.py
@@ -383,7 +383,7 @@ def add_config(
     cfg.x.default_selector = "default"
     cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
-    cfg.x.default_hist_producer = "cf_default"
+    cfg.x.default_hist_producer = "all_weights"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = "default"  # "uhh2"
     cfg.x.default_categories = ("incl",)
@@ -561,7 +561,6 @@ def add_config(
     # on command line via the '--weight_producer' parameter. To reproduce results from before this date,
     # you can use the 'all_weights' weight_producer defined in columnflow.weight.all_weights.
     # With cf 0.3.x, the 'weight_producer' has been renamed to 'hist_producer'.
-    cfg.x.default_hist_producer = "all_weights"
 
     # custom labels for selector steps
     cfg.x.selector_step_labels = {}

--- a/topsf/config/run2/config_sf.py
+++ b/topsf/config/run2/config_sf.py
@@ -381,6 +381,7 @@ def add_config(
     # ml model, inference model, etc
     cfg.x.default_calibrator = "default"
     cfg.x.default_selector = "default"
+    cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = "default"  # "uhh2"

--- a/topsf/config/run2/config_wp.py
+++ b/topsf/config/run2/config_wp.py
@@ -156,7 +156,7 @@ def add_config(
     cfg.x.default_selector = "wp"
     cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
-    cfg.x.default_hist_producer = "cf_default"
+    cfg.x.default_hist_producer = "all_weights"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = None
     cfg.x.default_categories = ("incl",)
@@ -214,7 +214,6 @@ def add_config(
     # on command line via the '--weight_producer' parameter. To reproduce results from before this date,
     # you can use the 'all_weights' weight_producer defined in columnflow.weight.all_weights:
     # With cf 0.3.x, the 'weight_producer' has been renamed to 'hist_producer'.
-    cfg.x.default_hist_producer = "all_weights"
 
     # custom labels for selector steps
     cfg.x.selector_step_labels = {}

--- a/topsf/config/run2/config_wp.py
+++ b/topsf/config/run2/config_wp.py
@@ -156,6 +156,7 @@ def add_config(
     cfg.x.default_selector = "wp"
     cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
+    cfg.x.default_hist_producer = "cf_default"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = None
     cfg.x.default_categories = ("incl",)

--- a/topsf/config/run2/config_wp.py
+++ b/topsf/config/run2/config_wp.py
@@ -213,7 +213,8 @@ def add_config(
     # You can add a 'default_weight_producer' to your config or directly add the weight_producer
     # on command line via the '--weight_producer' parameter. To reproduce results from before this date,
     # you can use the 'all_weights' weight_producer defined in columnflow.weight.all_weights:
-    cfg.x.default_weight_producer = "all_weights"
+    # With cf 0.3.x, the 'weight_producer' has been renamed to 'hist_producer'.
+    cfg.x.default_hist_producer = "all_weights"
 
     # custom labels for selector steps
     cfg.x.selector_step_labels = {}

--- a/topsf/config/run2/config_wp.py
+++ b/topsf/config/run2/config_wp.py
@@ -154,6 +154,7 @@ def add_config(
     # ml model, inference model, etc
     cfg.x.default_calibrator = "default"
     cfg.x.default_selector = "wp"
+    cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = None

--- a/topsf/config/run3/config_sf.py
+++ b/topsf/config/run3/config_sf.py
@@ -855,6 +855,7 @@ def add_config(
                 # "CorrelationGroupFlavor",
                 # "CorrelationGroupUncorrelated",
             ],
+            "data_per_era": True,
         },
         "FatJet": {
             "campaign": jerc_campaign,
@@ -920,6 +921,7 @@ def add_config(
                 # "CorrelationGroupFlavor",
                 # "CorrelationGroupUncorrelated",
             ],
+            "data_per_era": True,
         },
         "SubJet": {
             "campaign": jerc_campaign,
@@ -985,6 +987,7 @@ def add_config(
                 # "CorrelationGroupFlavor",
                 # "CorrelationGroupUncorrelated",
             ],
+            "data_per_era": True,
         },
     })
 
@@ -1000,8 +1003,7 @@ def add_config(
         "FatJet": {
             "campaign": jerc_campaign,
             "version": {2022: "JRV1"}[year],
-            "jet_type": jet_type,
-            "external_file_key": "jet_jerc",
+            "jet_type": fatjet_type,
         },
         "SubJet": {
             "campaign": jerc_campaign,

--- a/topsf/config/run3/config_sf.py
+++ b/topsf/config/run3/config_sf.py
@@ -415,6 +415,7 @@ def add_config(
     # ml model, inference model, etc
     cfg.x.default_calibrator = "default"
     cfg.x.default_selector = "default"
+    cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = "default"  # "uhh2"

--- a/topsf/config/run3/config_sf.py
+++ b/topsf/config/run3/config_sf.py
@@ -677,7 +677,8 @@ def add_config(
     # You can add a 'default_weight_producer' to your config or directly add the weight_producer
     # on command line via the '--weight_producer' parameter. To reproduce results from before this date,
     # you can use the 'all_weights' weight_producer defined in columnflow.weight.all_weights:
-    cfg.x.default_weight_producer = "all_weights"
+    # With cf 0.3.x, the 'weight_producer' has been renamed to 'hist_producer'.
+    cfg.x.default_hist_producer = "all_weights"
 
     # custom labels for selector steps
     cfg.x.selector_step_labels = {}

--- a/topsf/config/run3/config_sf.py
+++ b/topsf/config/run3/config_sf.py
@@ -1391,7 +1391,7 @@ def add_config(
     #
 
     # external files
-    json_mirror = "/afs/cern.ch/user/j/jmatthie/public/mirrors/jsonpog-integration-49ddc547"
+    json_mirror = "/afs/cern.ch/user/j/jmatthie/public/mirrors/jsonpog-integration-b7a48c75"
     local_repo = "/data/dust/user/matthiej/topsf"  # TODO: avoid hardcoding path
 
     if cfg.x.run == 3:

--- a/topsf/config/run3/config_sf.py
+++ b/topsf/config/run3/config_sf.py
@@ -417,6 +417,7 @@ def add_config(
     cfg.x.default_selector = "default"
     cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
+    cfg.x.default_hist_producer = "cf_default"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = "default"  # "uhh2"
     cfg.x.default_categories = ("incl",)

--- a/topsf/config/run3/config_sf.py
+++ b/topsf/config/run3/config_sf.py
@@ -417,7 +417,7 @@ def add_config(
     cfg.x.default_selector = "default"
     cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
-    cfg.x.default_hist_producer = "cf_default"
+    cfg.x.default_hist_producer = "all_weights"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = "default"  # "uhh2"
     cfg.x.default_categories = ("incl",)
@@ -678,7 +678,6 @@ def add_config(
     # on command line via the '--weight_producer' parameter. To reproduce results from before this date,
     # you can use the 'all_weights' weight_producer defined in columnflow.weight.all_weights:
     # With cf 0.3.x, the 'weight_producer' has been renamed to 'hist_producer'.
-    cfg.x.default_hist_producer = "all_weights"
 
     # custom labels for selector steps
     cfg.x.selector_step_labels = {}

--- a/topsf/config/run3/config_sf.py
+++ b/topsf/config/run3/config_sf.py
@@ -1644,7 +1644,7 @@ def add_config(
             # V+jets QCD NLO reweighting
             dataset.x.event_weights["vjets_weight"] = get_shifts("vjets")
         # add PSWeight variations for all datasets but qcd
-        if not dataset.has_tag("is_qcd"):
+        if not dataset.has_tag("is_qcd") and dataset.is_mc:
             dataset.x.event_weights["ISR"] = get_shifts("ISR")
             dataset.x.event_weights["FSR"] = get_shifts("FSR")
         if dataset.has_tag("has_top"):

--- a/topsf/config/run3/config_wp.py
+++ b/topsf/config/run3/config_wp.py
@@ -949,7 +949,7 @@ def add_config(
     #
 
     # external files
-    json_mirror = "/afs/cern.ch/user/j/jmatthie/public/mirrors/jsonpog-integration-49ddc547"
+    json_mirror = "/afs/cern.ch/user/j/jmatthie/public/mirrors/jsonpog-integration-b7a48c75"
     local_repo = "/data/dust/user/matthiej/topsf"  # TODO: avoid hardcoding path
 
     if cfg.x.run == 3:

--- a/topsf/config/run3/config_wp.py
+++ b/topsf/config/run3/config_wp.py
@@ -218,6 +218,7 @@ def add_config(
     # ml model, inference model, etc
     cfg.x.default_calibrator = "default"
     cfg.x.default_selector = "wp"
+    cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = None

--- a/topsf/config/run3/config_wp.py
+++ b/topsf/config/run3/config_wp.py
@@ -567,8 +567,7 @@ def add_config(
         "FatJet": {
             "campaign": jerc_campaign,
             "version": {2022: "JRV1"}[year],
-            "jet_type": jet_type,
-            "external_file_key": "jet_jerc",
+            "jet_type": fatjet_type,
         },
         "SubJet": {
             "campaign": jerc_campaign,
@@ -961,6 +960,9 @@ def add_config(
 
         # jet energy correction
         "jet_jerc": (f"{json_mirror}/POG/JME/{corr_tag}/jet_jerc.json.gz", "v1"),
+
+        # jet energy correction ak8
+        "fat_jet_jerc": (f"{json_mirror}/POG/JME/{corr_tag}/fatJet_jerc.json.gz", "v1"),
 
         # jet veto map
         "jet_veto_map": (f"{json_mirror}/POG/JME/{corr_tag}/jetvetomaps.json.gz", "v1"),

--- a/topsf/config/run3/config_wp.py
+++ b/topsf/config/run3/config_wp.py
@@ -220,7 +220,7 @@ def add_config(
     cfg.x.default_selector = "wp"
     cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
-    cfg.x.default_hist_producer = "cf_default"
+    cfg.x.default_hist_producer = "all_weights"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = None
     cfg.x.default_categories = ("incl",)
@@ -275,7 +275,6 @@ def add_config(
     # on command line via the '--weight_producer' parameter. To reproduce results from before this date,
     # you can use the 'all_weights' weight_producer defined in columnflow.weight.all_weights:
     # With cf 0.3.x, the 'weight_producer' has been renamed to 'hist_producer'.
-    cfg.x.default_hist_producer = "all_weights"
 
     # custom labels for selector steps
     cfg.x.selector_step_labels = {}

--- a/topsf/config/run3/config_wp.py
+++ b/topsf/config/run3/config_wp.py
@@ -274,7 +274,8 @@ def add_config(
     # You can add a 'default_weight_producer' to your config or directly add the weight_producer
     # on command line via the '--weight_producer' parameter. To reproduce results from before this date,
     # you can use the 'all_weights' weight_producer defined in columnflow.weight.all_weights:
-    cfg.x.default_weight_producer = "all_weights"
+    # With cf 0.3.x, the 'weight_producer' has been renamed to 'hist_producer'.
+    cfg.x.default_hist_producer = "all_weights"
 
     # custom labels for selector steps
     cfg.x.selector_step_labels = {}

--- a/topsf/config/run3/config_wp.py
+++ b/topsf/config/run3/config_wp.py
@@ -220,6 +220,7 @@ def add_config(
     cfg.x.default_selector = "wp"
     cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
+    cfg.x.default_hist_producer = "cf_default"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = None
     cfg.x.default_categories = ("incl",)

--- a/topsf/config/variables.py
+++ b/topsf/config/variables.py
@@ -96,7 +96,7 @@ def add_variables(config: od.Config) -> None:
     )
     config.add_variable(
         name="fatjet_tau32",
-        expression=lambda events: events['FatJet']['tau3'] / events['FatJet']['tau2'],
+        expression=lambda events: events["FatJet"]["tau3"] / events["FatJet"]["tau2"],
         null_value=EMPTY_FLOAT,
         binning=(50, 0, 1),
         x_title=r"AK8 jet $\tau_{3}/\tau_{2}$",

--- a/topsf/inference/uhh2.py
+++ b/topsf/inference/uhh2.py
@@ -3,7 +3,6 @@
 """
 TopSF inference model, based on UHH2 LegacyTopTagging analysis
 """
-import itertools
 from collections import defaultdict
 
 from columnflow.inference import inference_model, ParameterType, ParameterTransformation
@@ -40,7 +39,7 @@ def uhh2(self):
     for config_inst in self.config_insts:
         if config_inst.x.fit_setup is None:
             raise ValueError(
-                f"Config {config_inst.name} does not have a fit setup defined."
+                f"Config {config_inst.name} does not have a fit setup defined.",
             )
 
     # Use the first config as the reference

--- a/topsf/inference/uhh2.py
+++ b/topsf/inference/uhh2.py
@@ -4,8 +4,10 @@
 TopSF inference model, based on UHH2 LegacyTopTagging analysis
 """
 import itertools
+from collections import defaultdict
 
 from columnflow.inference import inference_model, ParameterType, ParameterTransformation
+from columnflow.config_util import get_datasets_from_process
 
 
 def get_process_datasets(config_inst, process):
@@ -27,117 +29,177 @@ def uhh2(self):
     """
     Inference model intended to reproduce the fits in UHH2 LegacyTopTagging analysis.
     """
-
-    year = self.config_inst.campaign.x.year  # noqa; not used right now
-
-    processes = self.config_inst.x.inference_processes
+    processes = set()
+    for config_inst in self.config_insts:
+        processes.update(config_inst.x.inference_processes)
 
     #
     # regions/categories
     #
+    # Validate all configs have a fit setup defined
+    for config_inst in self.config_insts:
+        if config_inst.x.fit_setup is None:
+            raise ValueError(
+                f"Config {config_inst.name} does not have a fit setup defined."
+            )
 
-    #
-    # categories
-    #
+    # Use the first config as the reference
+    ref_setup = self.config_insts[0].x.fit_setup
+    ref_channels = ref_setup["channels"]
+    ref_pt_bins = ref_setup["pt_bins"]
+    ref_wp_names = ref_setup["wp_names"]
+    ref_fit_vars = ref_setup["fit_vars"][0]  # Assuming single var for now
+    ref_shape_unc = ref_setup["shape_unc"]
 
-    # category elements to combine in fit
-    years = [
-        year % 100,
-    ]
-    channels = self.config_inst.x.fit_setup["channels"]
-    pt_bins = self.config_inst.x.fit_setup["pt_bins"]
-    wp_names = self.config_inst.x.fit_setup["wp_names"]
-    fit_vars = self.config_inst.x.fit_setup["fit_vars"][0]  # TODO: do we need to support multiple vars?
+    # Compare the rest against the reference
+    for config_inst in self.config_insts[1:]:
+        setup = config_inst.x.fit_setup
+        if setup["channels"] != ref_channels:
+            raise ValueError(f"Config {config_inst.name} has different channels.")
+        if setup["pt_bins"] != ref_pt_bins:
+            raise ValueError(f"Config {config_inst.name} has different pt_bins.")
+        if setup["wp_names"] != ref_wp_names:
+            raise ValueError(f"Config {config_inst.name} has different wp_names.")
+        if setup["fit_vars"][0] != ref_fit_vars:
+            raise ValueError(f"Config {config_inst.name} has different fit_vars[0].")
+        if setup["shape_unc"] != ref_shape_unc:
+            raise ValueError(f"Config {config_inst.name} has different shape_unc.")
+
+    # Now safe to assign
+    channels = ref_channels
+    pt_bins = ref_pt_bins
+    wp_names = ref_wp_names
+    fit_vars = ref_fit_vars
+    shape_unc = ref_shape_unc
 
     # tuples of inference categories and
     # corresponding config category names
     categories = [
         # (columnflow_name, combine_name)
         (f"{channel}__{pt_bin}__tau32_wp_{wp_name}_{region}",
-        f"bin_{channel}__{year}__{pt_bin}__tau32_wp_{wp_name}_{region}")
-        for channel, year, pt_bin, wp_name, region in itertools.product(
-            channels,
-            years,
-            pt_bins,
-            wp_names,
-            ("pass", "fail"),
-        )
+        f"bin_{channel}__{pt_bin}__tau32_wp_{wp_name}_{region}")
+        for channel in channels
+        for pt_bin in pt_bins
+        for wp_name in wp_names
+        for region in ("pass", "fail")
     ]
 
-    # add categories to inference model
     for config_cat, inference_cat in categories:
-        self.add_category(
-            inference_cat,
-            config_category=config_cat,
-            config_variable=fit_vars,
-            mc_stats="0 1 1",
-            config_data_datasets=get_process_datasets(self.config_inst, "data"),
-            # fake data from sum of MC processes
-            data_from_processes=processes,
-            # empty bins should stay empty!!
-            empty_bin_value=0.0,
+
+        var_name = fit_vars
+        if not all(has_var := [config_inst.has_variable(var_name) for config_inst in self.config_insts]):
+            missing_var_configs = [
+                config_inst.name for config_inst, has_var in zip(self.config_insts, has_var) if not has_var
+            ]
+            raise ValueError(
+                f"Variable {var_name} not found in configs {', '.join(missing_var_configs)} "
+                f"for {config_cat}. Please ensure that {var_name} is part of all configs.",
+            )
+        cat_name = inference_cat
+        cat_kwargs = dict(
+            config_data={
+                config_inst.name: self.category_config_spec(
+                    category=config_cat,
+                    variable=var_name,
+                    data_datasets=[
+                        dataset_inst.name for dataset_inst in
+                        get_datasets_from_process(config_inst, "data", strategy="all", only_first=False)
+                    ],
+                )
+                for config_inst in self.config_insts
+            },
+            mc_stats="0 1 1",  # FIXME: make configurable
+            flow_strategy="move",
+            empty_bin_value=0.0,  # NOTE: remove this when removing custom rebin task
         )
+
+        # add the category to the inference model
+        # print(f"Adding category {inference_cat} with config category {config_cat} and variable {var_name}.")
+        self.add_category(cat_name, **cat_kwargs)
 
     #
     # processes
     #
-
-    # different naming convention in combine for some processes
     inference_processes = {}
 
+    used_datasets = defaultdict(set)
     for proc in processes:
+        if any(missing_proc := [not config.has_process(proc) for config in self.config_insts]):
+            config_missing = [
+                config_inst.name for config_inst, missing in zip(self.config_insts, missing_proc)
+                if missing
+            ]
+            raise Exception(f"Process {proc} is not defined in configs {', '.join(config_missing)}.")
 
-        # raise if process not defined in config
-        if not self.config_inst.has_process(proc):
-            raise ValueError(
-                f"Process {proc} requested for inference, but is not "
-                f"present in the config {self.config_inst.name}.",
-            )
+        # get datasets corresponding to this process
+        datasets = {config_inst.name: [
+            d.name for d in
+            get_datasets_from_process(config_inst, proc, strategy="all", check_deep=True, only_first=False)
+        ] for config_inst in self.config_insts}
 
-        # determine datasets for process
-        datasets = get_process_datasets(self.config_inst, proc)
+        for config, _datasets in datasets.items():
+            if not _datasets:
+                raise Exception(
+                    f"No datasets found for process {proc} in config {config}. "
+                    "Please check your configuration.",
+                )
+            # print(f"Process {proc} in config {config} was assigned datasets: {datasets}")
 
-        # check if process is signal
-        is_signal = self.config_inst.get_process(proc).has_tag("is_topsf_signal")
+            used_datasets[config] |= set(_datasets)
 
-        # add process to inference model
+        # print(f"Adding process {proc} with datasets: {datasets}")
         self.add_process(
-            inference_processes.get(proc, proc),
-            config_process=proc,
-            is_signal=is_signal,
-            config_mc_datasets=datasets,
+            name=inference_processes.get(proc, proc),
+            config_data={
+                config_inst.name: self.process_config_spec(
+                    process=proc,
+                    mc_datasets=datasets[config_inst.name],
+                )
+                for config_inst in self.config_insts
+            },
+            is_signal=self.config_insts[0].get_process(proc).has_tag("is_topsf_signal"),
+            # is_dynamic=??,
         )
 
     #
     # parameters
+    # FIXME: assumes all configs have the same uncertainties assigned to the same processes
     #
 
     # lumi
-    lumi = self.config_inst.x.luminosity
-    for unc_name in lumi.uncertainties:
+    lumi_uncertainties = {
+        lumi_unc: config_inst.x.luminosity.get(names=lumi_unc, direction=("down", "up"), factor=True)
+        for config_inst in self.config_insts
+        for lumi_unc in config_inst.x.luminosity.uncertainties
+    }
+    for lumi_unc_name, effect in lumi_uncertainties.items():
+        # print(f"Adding luminosity uncertainty parameter {lumi_unc_name} with effect {effect}.")
         self.add_parameter(
-            unc_name,
+            lumi_unc_name,
             type=ParameterType.rate_gauss,
-            effect=lumi.get(names=unc_name, direction=("down", "up"), factor=True),
+            effect=effect,
             transformations=[ParameterTransformation.symmetrize],
         )
 
-    for proc in self.config_inst.x.process_rates.keys():
+    for proc in self.config_insts[0].x.process_rates.keys():
         subprocesses = [
-            subproc.name for subproc, _, _ in self.config_inst.get_process(proc).walk_processes(
+            subproc.name for subproc, _, _ in self.config_insts[0].get_process(proc).walk_processes(
                 algo="bfs",
                 include_self=True,
             )
         ]
+        # print(f"Adding process rate parameter for {proc} with subprocesses: {subprocesses}.")
         self.add_parameter(
             f"xsec_{proc}",
             type=ParameterType.rate_gauss,
-            effect=self.config_inst.x.process_rates[proc],
+            effect=self.config_insts[0].x.process_rates[proc],
             process=[inference_processes.get(subproc, subproc) for subproc in subprocesses],
         )
 
     # systematic shifts (TODO: add others)
-    uncertainty_shifts = self.config_inst.x.fit_setup["shape_unc"]
+    uncertainty_shifts = shape_unc
+
+    # old list left for reference
     # uncertainty_shifts = [
     #     # "pdf",
     #     # "mcscale",
@@ -165,6 +227,7 @@ def uhh2(self):
     inference_pars = {
         "minbias_xs": "pu",
     }
+    param_kwargs = {}
 
     for proc in processes:
         for unc in uncertainty_shifts:
@@ -173,11 +236,18 @@ def uhh2(self):
             if unc in ["mur", "muf"] and not (proc.startswith("st") or proc.startswith("tt")):
                 continue
             par = inference_pars.get(unc, unc)
+            param_kwargs["config_data"] = {
+                config_inst.name: self.parameter_config_spec(
+                    shift_source=unc,
+                )
+                for config_inst in self.config_insts
+            }
+            # print(f"Adding parameter {par} for process {proc} with uncertainty {unc}.")
             self.add_parameter(
                 f"{par}",
                 process=inference_processes.get(proc, proc),
                 type=ParameterType.shape,
-                config_shift_source=unc,
+                **param_kwargs,
             )
 
     self.cleanup()

--- a/topsf/inference/uhh2.py
+++ b/topsf/inference/uhh2.py
@@ -47,7 +47,7 @@ def uhh2(self):
     ref_channels = ref_setup["channels"]
     ref_pt_bins = ref_setup["pt_bins"]
     ref_wp_names = ref_setup["wp_names"]
-    ref_fit_vars = ref_setup["fit_vars"][0]  # Assuming single var for now
+    ref_fit_vars = ref_setup["fit_vars"]
     ref_shape_unc = ref_setup["shape_unc"]
 
     # Compare the rest against the reference
@@ -59,10 +59,19 @@ def uhh2(self):
             raise ValueError(f"Config {config_inst.name} has different pt_bins.")
         if setup["wp_names"] != ref_wp_names:
             raise ValueError(f"Config {config_inst.name} has different wp_names.")
-        if setup["fit_vars"][0] != ref_fit_vars:
-            raise ValueError(f"Config {config_inst.name} has different fit_vars[0].")
+        if setup["fit_vars"] != ref_fit_vars:
+            raise ValueError(f"Config {config_inst.name} has different fit_vars.")
         if setup["shape_unc"] != ref_shape_unc:
             raise ValueError(f"Config {config_inst.name} has different shape_unc.")
+
+        # Add check to make sure only one fit variable is used
+        if len(ref_fit_vars) != 1:
+            raise ValueError(
+                "Only one fit variable is supported. "
+                f"Found {len(ref_fit_vars)} variables in {config_inst.name}: {', '.join(ref_fit_vars)}.",
+            )
+
+    ref_fit_vars = ref_fit_vars[0]  # use the first fit variable in the given list
 
     # Now safe to assign
     channels = ref_channels

--- a/topsf/plotting/plot_all.py
+++ b/topsf/plotting/plot_all.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 from columnflow.util import DotDict, maybe_import
 from columnflow.plotting.plot_util import get_position
 from columnflow.plotting.plot_all import (
-    draw_error_bands,
+    draw_stat_error_bands,
+    # draw_syst_error_bands,  # FIXME not used
     draw_stack,
     draw_hist,
     draw_errorbars,
@@ -350,7 +351,7 @@ def plot_all(
 plot_all.plot_methods = {
     func.__name__: func
     for func in [
-        draw_error_bands,
+        draw_stat_error_bands,
         draw_stack,
         draw_hist,
         draw_errorbars,

--- a/topsf/plotting/plot_functions_1d.py
+++ b/topsf/plotting/plot_functions_1d.py
@@ -80,7 +80,7 @@ def plot_variable_stack(
         process_style_config,
         variable_style_config[variable_inst],
         style_config,
-        deep=True
+        deep=True,
     )
     if shape_norm:
         style_config["ax_cfg"]["ylabel"] = "Normalized entries"

--- a/topsf/plotting/plot_functions_1d.py
+++ b/topsf/plotting/plot_functions_1d.py
@@ -83,7 +83,7 @@ def plot_variable_stack(
         deep=True
     )
     if shape_norm:
-        style_config["ax_cfg"]["ylabel"] = r"$\Delta N/N$"
+        style_config["ax_cfg"]["ylabel"] = "Normalized entries"
 
     skip_legend = kwargs.pop("skip_legend", False)
     fig, axs = plot_all(plot_config, style_config, skip_legend=True, **kwargs)

--- a/topsf/plotting/plot_util.py
+++ b/topsf/plotting/plot_util.py
@@ -85,7 +85,7 @@ def prepare_plot_config(
         }
         if not hide_errors:
             plot_config["mc_uncert"] = {
-                "method": "draw_error_bands",
+                "method": "draw_stats_error_bands",
                 "hist": h_mc,
                 "kwargs": {"norm": mc_norm, "label": "MC stat. unc."},
                 "ratio_kwargs": {"norm": h_mc.values()},

--- a/topsf/production/gen_v.py
+++ b/topsf/production/gen_v.py
@@ -7,8 +7,9 @@ Producers for L1 prefiring weights.
 from __future__ import annotations
 
 from columnflow.production import Producer, producer
-from columnflow.util import maybe_import, InsertableDict, DotDict
+from columnflow.util import maybe_import, DotDict
 from columnflow.columnar_util import set_ak_column
+from law.util import InsertableDict
 
 
 np = maybe_import("numpy")

--- a/topsf/production/gen_v.py
+++ b/topsf/production/gen_v.py
@@ -210,7 +210,13 @@ def vjets_weight_requires(self: Producer, task: law.Task, reqs: dict) -> None:
 
 
 @vjets_weight.setup
-def vjets_weight_setup(self: Producer, task: law.Task, reqs: dict, inputs: dict, reader_targets: InsertableDict) -> None:
+def vjets_weight_setup(
+    self: Producer,
+    task: law.Task,
+    reqs: dict,
+    inputs: dict,
+    reader_targets: InsertableDict,
+) -> None:
     bundle = reqs["external_files"]
 
     # create the L1 prefiring weight evaluator

--- a/topsf/production/gen_v.py
+++ b/topsf/production/gen_v.py
@@ -3,8 +3,8 @@
 """
 Producers for L1 prefiring weights.
 """
-
 from __future__ import annotations
+import law
 
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import, DotDict
@@ -201,16 +201,16 @@ def vjets_weight_init(self: Producer) -> None:
 
 
 @vjets_weight.requires
-def vjets_weight_requires(self: Producer, reqs: dict) -> None:
+def vjets_weight_requires(self: Producer, task: law.Task, reqs: dict) -> None:
     if "external_files" in reqs:
         return
 
     from columnflow.tasks.external import BundleExternalFiles
-    reqs["external_files"] = BundleExternalFiles.req(self.task)
+    reqs["external_files"] = BundleExternalFiles.req(task)
 
 
 @vjets_weight.setup
-def vjets_weight_setup(self: Producer, reqs: dict, inputs: dict, reader_targets: InsertableDict) -> None:
+def vjets_weight_setup(self: Producer, task: law.Task, reqs: dict, inputs: dict, reader_targets: InsertableDict) -> None:
     bundle = reqs["external_files"]
 
     # create the L1 prefiring weight evaluator

--- a/topsf/production/l1_prefiring.py
+++ b/topsf/production/l1_prefiring.py
@@ -13,8 +13,9 @@ from functools import reduce
 
 from columnflow.production import Producer, producer
 from columnflow.production.util import attach_coffea_behavior
-from columnflow.util import maybe_import, InsertableDict, DotDict
+from columnflow.util import maybe_import, DotDict
 from columnflow.columnar_util import set_ak_column, flat_np_view, layout_ak_array
+from law.util import InsertableDict
 
 
 np = maybe_import("numpy")

--- a/topsf/production/normalization.py
+++ b/topsf/production/normalization.py
@@ -3,6 +3,7 @@
 """
 Column production methods related to sample normalization event weights.
 """
+import law
 
 from collections import defaultdict
 
@@ -50,20 +51,26 @@ def normalization_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Arra
 
 
 @normalization_weights.requires
-def normalization_weights_requires(self: Producer, reqs: dict) -> None:
+def normalization_weights_requires(self: Producer, task: law.Task, reqs: dict) -> None:
     """
     Adds the requirements needed by the underlying py:attr:`task` to access selection stats into
     *reqs*.
     """
     from columnflow.tasks.selection import MergeSelectionStats
     reqs["selection_stats"] = MergeSelectionStats.req(
-        self.task,
+        task,
         branch=-1,
     )
 
 
 @normalization_weights.setup
-def normalization_weights_setup(self: Producer, reqs: dict, inputs: dict, reader_targets: InsertableDict) -> None:
+def normalization_weights_setup(
+    self: Producer,
+    task: law.Task,
+    reqs: dict,
+    inputs: dict,
+    reader_targets: InsertableDict,
+) -> None:
     """
     Sets up objects required by the computation of normalization weights and stores them as instance
     attributes:

--- a/topsf/production/normalization.py
+++ b/topsf/production/normalization.py
@@ -7,8 +7,9 @@ Column production methods related to sample normalization event weights.
 from collections import defaultdict
 
 from columnflow.production import Producer, producer
-from columnflow.util import maybe_import, InsertableDict
+from columnflow.util import maybe_import
 from columnflow.columnar_util import set_ak_column
+from law.util import InsertableDict
 
 
 np = maybe_import("numpy")

--- a/topsf/production/probe_jet.py
+++ b/topsf/production/probe_jet.py
@@ -292,7 +292,7 @@ def probe_jet(
     events = set_ak_column(events, "ProbeJet.n_merged", n_merged)
 
     for v in ("pt", "eta", "phi", "mass", "tau3", "tau2", "msoftdrop"):
-        events = set_ak_column(events, f"ProbeJet.{v}", probejet[v])
+        events = set_ak_column(events, f"ProbeJet['{v}']", probejet[v])
 
     events = set_ak_column(
         events,

--- a/topsf/production/weights.py
+++ b/topsf/production/weights.py
@@ -30,10 +30,10 @@ def weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
     if self.dataset_inst.is_mc:
         if not has_tag("skip_electron_weights", self.config_inst, self.dataset_inst, operator=any):
-            electron_mask = (events.Electron.pt >= 35)
+            electron_mask = (events.Electron["pt"] >= 35)
             events = self[electron_weights](events, electron_mask=electron_mask, **kwargs)
         if not has_tag("skip_muon_weights", self.config_inst, self.dataset_inst, operator=any):
-            muon_mask = (events.Muon.pt >= 30) & (abs(events.Muon.eta) < 2.4)
+            muon_mask = (events.Muon["pt"] >= 30) & (abs(events.Muon["eta"]) < 2.4)
             events = self[muon_weights](events, muon_mask=muon_mask, **kwargs)
 
         # # compute btag weights

--- a/topsf/selection/default.py
+++ b/topsf/selection/default.py
@@ -10,6 +10,7 @@ from collections import defaultdict, OrderedDict
 
 from columnflow.util import maybe_import
 from columnflow.columnar_util import optional_column as optional
+from columnflow.columnar_util import remove_ak_column, EMPTY_FLOAT
 
 from columnflow.selection import Selector, SelectionResult, selector
 from columnflow.selection.cms.met_filters import met_filters

--- a/topsf/selection/default.py
+++ b/topsf/selection/default.py
@@ -227,6 +227,22 @@ def default(
     # increment stats
     self[increment_stats](events, results, stats, **kwargs)
 
+    # remove unused columns
+    for col in ["GenPart", "GenPartonTop"]:
+        for field in [
+            "genPartIdxMother",
+            "statusFlags",
+            "genPartIdxMotherG",
+            "distinctParentIdxG",
+            "childrenIdxG",
+            "distinctChildrenIdxG",
+            "distinctChildrenDeepIdxG",
+        ]:
+            events = remove_ak_column(events, f"{col}.{field}", silent=True)
+
+    # avoid none values in events
+    events = ak.fill_none(events, EMPTY_FLOAT)
+
     return events, results
 
 

--- a/topsf/tasks/inference.py
+++ b/topsf/tasks/inference.py
@@ -61,7 +61,7 @@ class CreateDatacards(
             if merge_variables:
                 variables = tuple(
                     _cat_obj.config_data.get(config_inst.name).variable
-                    for _cat_obj in list(self.branch_map.values())[0]["categories"]  # different from cf implementation of SerializeInferenceModelBase
+                    for _cat_obj in list(self.branch_map.values())[0]["categories"]  # noqa: E501, different from cf implementation of SerializeInferenceModelBase
                 )
             else:
                 variables = (config_data.variable,)
@@ -143,7 +143,7 @@ class CreateDatacards(
         reqs = law.util.InsertableDict()
 
         reqs["merged_hists"] = hist_reqs = {}
-        for cat_obj in list(self.branch_map.values())[0]["categories"]:  # different from cf implementation of SerializeInferenceModelBase
+        for cat_obj in list(self.branch_map.values())[0]["categories"]:  # noqa: E501, different from cf implementation of SerializeInferenceModelBase
             cat_reqs = self._requires_cat_obj(cat_obj)
             for config_name, proc_reqs in cat_reqs.items():
                 hist_reqs.setdefault(config_name, {})
@@ -280,7 +280,7 @@ class CreateDatacards(
                                 # hists[proc_obj_name] = {}
                                 for d in ["up", "down"]:
                                     shift_inst = config_inst.get_shift(
-                                        f"{param_obj.config_data[config_inst.name].shift_source}_{d}"
+                                        f"{param_obj.config_data[config_inst.name].shift_source}_{d}",
                                     )
                                     hists[proc_obj_name][(param_obj.name, d)] = h_proc[
                                         {"shift": hist.loc(shift_inst.name)}
@@ -291,7 +291,7 @@ class CreateDatacards(
                             hists_all_cats[cat_obj.name] = OrderedDict()
 
                         for process_name, hist_dict in hists.items():
-                            hists_all_cats[cat_obj.name].setdefault(process_name, OrderedDict())[config_inst.name] = hist_dict
+                            hists_all_cats[cat_obj.name].setdefault(process_name, OrderedDict())[config_inst.name] = hist_dict  # noqa: E501
 
         # forward objects to the datacard writer
         outputs = self.output()

--- a/topsf/tasks/inference.py
+++ b/topsf/tasks/inference.py
@@ -12,7 +12,7 @@ import re
 
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
+    CalibratorsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
@@ -35,7 +35,6 @@ class CreateDatacards(
     InferenceModelMixin,
     MLModelsMixin,
     ProducersMixin,
-    SelectorStepsMixin,
     CalibratorsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,

--- a/topsf/tasks/inference.py
+++ b/topsf/tasks/inference.py
@@ -10,14 +10,10 @@ import luigi
 import law
 import re
 
-from columnflow.tasks.framework.base import Requirements, AnalysisTask, wrapper_factory
-from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
-)
-from columnflow.tasks.framework.remote import RemoteWorkflow
-from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
-from columnflow.util import dev_sandbox
-from columnflow.config_util import get_datasets_from_process
+from columnflow.tasks.framework.base import AnalysisTask, wrapper_factory
+from columnflow.tasks.framework.inference import SerializeInferenceModelBase
+from columnflow.tasks.histograms import MergeHistograms
+from columnflow.util import DotDict
 
 from topsf.tasks.base import TopSFTask
 
@@ -32,14 +28,9 @@ def multi_string_repr(strings, max_len=1, sep="_"):
 
 class CreateDatacards(
     TopSFTask,
-    InferenceModelMixin,
-    MLModelsMixin,
-    ProducersMixin,
-    CalibratorsMixin,
-    law.LocalWorkflow,
-    RemoteWorkflow,
+    SerializeInferenceModelBase,
 ):
-    sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
+    resolution_task_cls = MergeHistograms
 
     per_category = luigi.BoolParameter(
         default=False,
@@ -52,13 +43,73 @@ class CreateDatacards(
         description="working point to use for the fit",
     )
 
-    # upstream requirements
-    reqs = Requirements(
-        RemoteWorkflow.reqs,
-        MergeHistograms=MergeHistograms,
-        MergeShiftedHistograms=MergeShiftedHistograms,
-    )
+    def _requires_cat_obj(self, cat_obj: DotDict, merge_variables: bool = False, **req_kwargs):
+        """
+        Custom helper to create the requirements for a single category object.
+        The difference to the columnflow.tasks.framework.inference.SerializeInferenceModelBase
+        implementation is the due to the different branch_map structure.
 
+        :param cat_obj: category object from an InferenceModel
+        :param merge_variables: whether to merge the variables from all requested category objects
+        :return: requirements for the category object
+        """
+        reqs = {}
+        for config_inst in self.config_insts:
+            if not (config_data := cat_obj.config_data.get(config_inst.name)):
+                continue
+
+            if merge_variables:
+                variables = tuple(
+                    _cat_obj.config_data.get(config_inst.name).variable
+                    for _cat_obj in list(self.branch_map.values())[0]["categories"]  # different from cf implementation of SerializeInferenceModelBase
+                )
+            else:
+                variables = (config_data.variable,)
+
+            # add merged shifted histograms for mc
+            reqs[config_inst.name] = {
+                proc_obj.name: {
+                    dataset: self.reqs.MergeShiftedHistograms.req_different_branching(
+                        self,
+                        config=config_inst.name,
+                        dataset=dataset,
+                        shift_sources=tuple(
+                            param_obj.config_data[config_inst.name].shift_source
+                            for param_obj in proc_obj.parameters
+                            if (
+                                config_inst.name in param_obj.config_data and
+                                self.inference_model_inst.require_shapes_for_parameter(param_obj)
+                            )
+                        ),
+                        variables=variables,
+                        **req_kwargs,
+                    )
+                    for dataset in self.get_mc_datasets(config_inst, proc_obj)
+                }
+                for proc_obj in cat_obj.processes
+                if config_inst.name in proc_obj.config_data and not proc_obj.is_dynamic
+            }
+            # add merged histograms for data, but only if
+            # - data in that category is not faked from mc, or
+            # - at least one process object is dynamic (that usually means data-driven)
+            if (
+                (not cat_obj.data_from_processes or any(proc_obj.is_dynamic for proc_obj in cat_obj.processes)) and
+                (data_datasets := self.get_data_datasets(config_inst, cat_obj))
+            ):
+                reqs[config_inst.name]["data"] = {
+                    dataset: self.reqs.MergeHistograms.req_different_branching(
+                        self,
+                        config=config_inst.name,
+                        dataset=dataset,
+                        variables=variables,
+                        **req_kwargs,
+                    )
+                    for dataset in data_datasets
+                }
+        return reqs
+
+    # custom function required to create the branch map
+    # unchanged
     def create_branch_map(self):
         cats = list(self.inference_model_inst.categories)
 
@@ -68,7 +119,7 @@ class CreateDatacards(
         # Filter categories to include only those with the specified wp in user input
         filtered_cats = []
         for cat in cats:
-            config_category = cat.config_category
+            config_category = cat.name
             if re.match(pattern, config_category):
                 filtered_cats.append(cat)
 
@@ -87,73 +138,34 @@ class CreateDatacards(
             ]
 
     def workflow_requires(self):
-        reqs = super().workflow_requires()
+        # why does this not work?
+        # reqs = super().workflow_requires()
+        reqs = law.util.InsertableDict()
 
-        # simply require the requirements of all branch tasks right now
-        reqs["merged_hists"] = set(sum((
-            law.util.flatten(t.requires())
-            for t in self.get_branch_tasks().values()
-        ), []))
-
+        reqs["merged_hists"] = hist_reqs = {}
+        for cat_obj in list(self.branch_map.values())[0]["categories"]:  # different from cf implementation of SerializeInferenceModelBase
+            cat_reqs = self._requires_cat_obj(cat_obj)
+            for config_name, proc_reqs in cat_reqs.items():
+                hist_reqs.setdefault(config_name, {})
+                for proc_name, dataset_reqs in proc_reqs.items():
+                    hist_reqs[config_name].setdefault(proc_name, {})
+                    for dataset_name, task in dataset_reqs.items():
+                        hist_reqs[config_name][proc_name].setdefault(dataset_name, set()).add(task)
         return reqs
 
     def requires(self):
-        # helper to find automatic datasets
-        def get_mc_datasets(proc_obj: dict) -> list[str]:
-            # when datasets are defined on the process object itself, return them
-            if proc_obj.config_mc_datasets:
-                return proc_obj.config_mc_datasets
-
-            # if not, check the config
-            return [
-                dataset_inst.name
-                for dataset_inst in get_datasets_from_process(
-                    self.config_inst,
-                    proc_obj.config_process,
-                    check_deep=True,
-                )
-            ]
-
-        cat_objs = self.branch_data["categories"]
+        cat_objs = list(self.branch_map.values())[0]["categories"]
         reqs = {}
         for cat_obj in cat_objs:
-            reqs_cat = reqs[cat_obj.name] = {
-                proc_obj.name: {
-                    dataset: self.reqs.MergeShiftedHistograms.req(
-                        self,
-                        dataset=dataset,
-                        shift_sources=tuple(
-                            param_obj.config_shift_source
-                            for param_obj in proc_obj.parameters
-                            if self.inference_model_inst.require_shapes_for_parameter(param_obj)
-                        ),
-                        variables=(cat_obj.config_variable,),
-                        branch=-1,
-                        _exclude={"branches"},
-                    )
-                    for dataset in get_mc_datasets(proc_obj)
-                }
-                for proc_obj in cat_obj.processes
-            }
-            if cat_obj.config_data_datasets:
-                reqs_cat["data"] = {
-                    dataset: self.reqs.MergeHistograms.req(
-                        self,
-                        dataset=dataset,
-                        variables=(cat_obj.config_variable,),
-                        branch=-1,
-                        _exclude={"branches"},
-                    )
-                    for dataset in cat_obj.config_data_datasets
-                }
+            reqs[cat_obj.name] = self._requires_cat_obj(cat_obj, branch=-1, workflow="local")
 
         return reqs
 
     def output(self):
         cat_objs = self.branch_data["categories"]
 
-        categories = {cat_obj.config_category for cat_obj in cat_objs}
-        variables = {cat_obj.config_variable for cat_obj in cat_objs}
+        categories = {cat_obj.config_data[self.config_insts[0].name].category for cat_obj in cat_objs}
+        variables = {cat_obj.config_data[self.config_insts[0].name].variable for cat_obj in cat_objs}
         categories_repr = multi_string_repr(categories)
         variables_repr = multi_string_repr(variables)
 
@@ -174,104 +186,118 @@ class CreateDatacards(
     def run(self):
         import hist
         from columnflow.inference.cms.datacard import DatacardWriter
+        print("Creating datacards ...")
 
         # prepare inputs
         inputs = self.input()
 
-        # prepare config objects
         cat_objs = self.branch_data["categories"]
+
+        # reference config, assuming all configs use the same categories, processes, and fit variable
+        ref_config_inst = self.config_insts[0]
 
         hists_all_cats = OrderedDict()
         for cat_obj in cat_objs:
-            category_inst = self.config_inst.get_category(cat_obj.config_category)
-            variable_inst = self.config_inst.get_variable(cat_obj.config_variable)
+            category_inst = ref_config_inst.get_category(cat_obj.config_data[ref_config_inst.name].category)
+            variable_inst = ref_config_inst.get_variable(cat_obj.config_data[ref_config_inst.name].variable)
             leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
 
             # histogram data per process
-            hists = OrderedDict()
 
             with self.publish_step(f"extracting {variable_inst.name} in {category_inst.name} ..."):
-                for proc_obj_name, inp in inputs[cat_obj.name].items():
-                    if proc_obj_name == "data":
-                        proc_obj = None
-                        process_inst = self.config_inst.get_process("data")
-                    else:
-                        proc_obj = self.inference_model_inst.get_process(proc_obj_name, category=cat_obj.name)
-                        process_inst = self.config_inst.get_process(proc_obj.config_process)
-                    sub_process_insts = [sub for sub, _, _ in process_inst.walk_processes(include_self=True)]
+                inputs[cat_obj.name] = inputs[cat_obj.name].copy()
 
-                    h_proc = None
-                    for dataset, _inp in inp.items():
-                        dataset_inst = self.config_inst.get_dataset(dataset)
-
-                        # skip when the dataset is already known to not contain any sub process
-                        if not any(map(dataset_inst.has_process, sub_process_insts)):
-                            self.logger.warning(
-                                f"dataset '{dataset}' does not contain process '{process_inst.name}' "
-                                "or any of its subprocesses which indicates a misconfiguration in the "
-                                f"inference model '{self.inference_model}'",
-                            )
-                            continue
-
-                        # open the histogram and work on a copy
-                        h = _inp["collection"][0]["hists"][variable_inst.name].load(formatter="pickle").copy()
-
-                        # axis selections
-                        h = h[{
-                            "process": [
-                                hist.loc(p.id)
-                                for p in sub_process_insts
-                                if p.id in h.axes["process"]
-                            ],
-                            "category": [
-                                hist.loc(c.id)
-                                for c in leaf_category_insts
-                                if c.id in h.axes["category"]
-                            ],
-                        }]
-
-                        # axis reductions
-                        h = h[{"process": sum, "category": sum}]
-
-                        # add the histogram for this dataset
-                        if h_proc is None:
-                            h_proc = h
+                for config_inst in self.config_insts:
+                    hists = OrderedDict()
+                    print(f"Processing config: {config_inst.name}")
+                    for proc_obj_name, inp in inputs[cat_obj.name][config_inst.name].items():
+                        if proc_obj_name == "data":
+                            proc_obj = None
+                            process_inst = config_inst.get_process("data")
                         else:
-                            h_proc += h
+                            proc_obj = self.inference_model_inst.get_process(proc_obj_name, category=cat_obj.name)
+                            process_inst = config_inst.get_process(proc_obj.config_data[config_inst.name].process)
+                        sub_process_insts = [sub for sub, _, _ in process_inst.walk_processes(include_self=True)]
 
-                    # there must be a histogram
-                    if h_proc is None:
-                        raise Exception(f"no histograms found for process '{process_inst.name}'")
+                        h_proc = None
+                        for dataset, _inp in inp.items():
+                            dataset_inst = config_inst.get_dataset(dataset)
 
-                    # create the nominal hist
-                    hists[proc_obj_name] = OrderedDict()
-                    nominal_shift_inst = self.config_inst.get_shift("nominal")
-                    hists[proc_obj_name]["nominal"] = h_proc[
-                        {"shift": hist.loc(nominal_shift_inst.id)}
-                    ]
-
-                    # per shift
-                    if proc_obj:
-                        for param_obj in proc_obj.parameters:
-                            # skip the parameter when varied hists are not needed
-                            if not self.inference_model_inst.require_shapes_for_parameter(param_obj):
+                            # skip when the dataset is already known to not contain any sub process
+                            if not any(map(dataset_inst.has_process, sub_process_insts)):
+                                self.logger.warning(
+                                    f"dataset '{dataset}' does not contain process '{process_inst.name}' "
+                                    "or any of its subprocesses which indicates a misconfiguration in the "
+                                    f"inference model '{self.inference_model}'",
+                                )
                                 continue
-                            # store the varied hists
-                            hists[proc_obj_name][param_obj.name] = {}
-                            for d in ["up", "down"]:
-                                shift_inst = self.config_inst.get_shift(f"{param_obj.config_shift_source}_{d}")
-                                hists[proc_obj_name][param_obj.name][d] = h_proc[
-                                    {"shift": hist.loc(shift_inst.id)}
-                                ]
 
-                    # store hists for this category
-                    hists_all_cats[cat_obj.name] = hists
+                            # open the histogram and work on a copy
+                            h = _inp["collection"][0]["hists"][variable_inst.name].load(formatter="pickle").copy()
+                            # print(f"Loaded histograms for dataset '{dataset}' and variable '{variable_inst.name}'")
 
-            # forward objects to the datacard writer
-            outputs = self.output()
-            writer = DatacardWriter(self.inference_model_inst, hists_all_cats)
-            with outputs["card"].localize("w") as tmp_card, outputs["shapes"].localize("w") as tmp_shapes:
-                writer.write(tmp_card.path, tmp_shapes.path, shapes_path_ref=outputs["shapes"].basename)
+                            # axis selections
+                            h = h[{
+                                "process": [
+                                    hist.loc(p.name)
+                                    for p in sub_process_insts
+                                    if p.name in h.axes["process"]
+                                ],
+                                "category": [
+                                    hist.loc(c.name)
+                                    for c in leaf_category_insts
+                                    if c.name in h.axes["category"]
+                                ],
+                            }]
+
+                            # axis reductions
+                            h = h[{"process": sum, "category": sum}]
+
+                            # add the histogram for this dataset
+                            if h_proc is None:
+                                h_proc = h
+                            else:
+                                h_proc += h
+
+                        # there must be a histogram
+                        if h_proc is None:
+                            raise Exception(f"no histograms found for process '{process_inst.name}'")
+
+                        # create the nominal hist
+                        hists[proc_obj_name] = OrderedDict()
+                        nominal_shift_inst = config_inst.get_shift("nominal")
+                        hists[proc_obj_name]["nominal"] = h_proc[
+                            {"shift": hist.loc(nominal_shift_inst.name)}
+                        ]
+
+                        # per shift
+                        if proc_obj:
+                            for param_obj in proc_obj.parameters:
+                                # skip the parameter when varied hists are not needed
+                                if not self.inference_model_inst.require_shapes_for_parameter(param_obj):
+                                    continue
+                                # store the varied hists
+                                # hists[proc_obj_name] = {}
+                                for d in ["up", "down"]:
+                                    shift_inst = config_inst.get_shift(
+                                        f"{param_obj.config_data[config_inst.name].shift_source}_{d}"
+                                    )
+                                    hists[proc_obj_name][(param_obj.name, d)] = h_proc[
+                                        {"shift": hist.loc(shift_inst.name)}
+                                    ]
+
+                        # store hists for this category
+                        if cat_obj.name not in hists_all_cats:
+                            hists_all_cats[cat_obj.name] = OrderedDict()
+
+                        for process_name, hist_dict in hists.items():
+                            hists_all_cats[cat_obj.name].setdefault(process_name, OrderedDict())[config_inst.name] = hist_dict
+
+        # forward objects to the datacard writer
+        outputs = self.output()
+        writer = DatacardWriter(self.inference_model_inst, hists_all_cats)
+        with outputs["card"].localize("w") as tmp_card, outputs["shapes"].localize("w") as tmp_shapes:
+            writer.write(tmp_card.path, tmp_shapes.path, shapes_path_ref=outputs["shapes"].basename)
 
 
 CreateDatacardsWrapper = wrapper_factory(

--- a/topsf/tasks/inference_tasks/combine_task.py
+++ b/topsf/tasks/inference_tasks/combine_task.py
@@ -64,7 +64,7 @@ import shutil
 
 from columnflow.tasks.framework.base import Requirements, CommandTask
 from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
+    CalibratorsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from topsf.tasks.inference_tasks.create_workspace import CreateWorkspace
@@ -78,7 +78,6 @@ class CombineTask(
     InferenceModelMixin,
     MLModelsMixin,
     ProducersMixin,
-    SelectorStepsMixin,
     CalibratorsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,

--- a/topsf/tasks/inference_tasks/create_workspace.py
+++ b/topsf/tasks/inference_tasks/create_workspace.py
@@ -24,7 +24,7 @@ import os
 
 from columnflow.tasks.framework.base import Requirements, CommandTask
 from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
+    CalibratorsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from topsf.tasks.inference import CreateDatacards
@@ -38,7 +38,6 @@ class CreateWorkspace(
     InferenceModelMixin,
     MLModelsMixin,
     ProducersMixin,
-    SelectorStepsMixin,
     CalibratorsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,

--- a/topsf/tasks/inference_tasks/impacts.py
+++ b/topsf/tasks/inference_tasks/impacts.py
@@ -51,7 +51,7 @@ import os
 
 from columnflow.tasks.framework.base import Requirements, CommandTask
 from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
+    CalibratorsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from topsf.tasks.inference_tasks.create_workspace import CreateWorkspace
@@ -67,7 +67,6 @@ class Impacts(
     InferenceModelMixin,
     MLModelsMixin,
     ProducersMixin,
-    SelectorStepsMixin,
     CalibratorsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
@@ -290,7 +289,6 @@ class PlotImpacts(
     InferenceModelMixin,
     MLModelsMixin,
     ProducersMixin,
-    SelectorStepsMixin,
     CalibratorsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,

--- a/topsf/tasks/inference_tasks/postfitshapes.py
+++ b/topsf/tasks/inference_tasks/postfitshapes.py
@@ -24,7 +24,7 @@ import os
 
 from columnflow.tasks.framework.base import Requirements, CommandTask
 from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
+    CalibratorsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from topsf.tasks.inference_tasks.create_workspace import CreateWorkspace
@@ -39,7 +39,6 @@ class PostFitShapesFromWorkspace(
     InferenceModelMixin,
     MLModelsMixin,
     ProducersMixin,
-    SelectorStepsMixin,
     CalibratorsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,

--- a/topsf/tasks/inference_v2/inference_base.py
+++ b/topsf/tasks/inference_v2/inference_base.py
@@ -9,7 +9,7 @@ from columnflow.tasks.framework.remote import RemoteWorkflow
 from topsf.tasks.inference import CreateDatacards
 from columnflow.util import dev_sandbox
 from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
+    CalibratorsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
 )
 
 from topsf.tasks.inference_v2.mixins import FitMixin
@@ -22,7 +22,6 @@ class InferenceBaseTask(
     InferenceModelMixin,
     MLModelsMixin,
     ProducersMixin,
-    SelectorStepsMixin,
     CalibratorsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,

--- a/topsf/tasks/plotting.py
+++ b/topsf/tasks/plotting.py
@@ -69,7 +69,7 @@ class PlotVariables1D(
                     if config_inst.name == config:
                         for dataset, inp in ds_inp.items():
                             dataset_inst = config_inst.get_dataset(dataset)
-                            h_in = inp["collection"][0]["hists"].targets[self.branch_data.variable].load(formatter="pickle")
+                            h_in = inp["collection"][0]["hists"].targets[self.branch_data.variable].load(formatter="pickle")  # noqa: E501
 
                             # loop and extract one histogram per process
                             for process_inst in process_insts:
@@ -96,7 +96,7 @@ class PlotVariables1D(
                                         hist.loc(s.name)
                                         for s in plot_shifts
                                         if s.name in h.axes["shift"]
-                                    ]
+                                    ],
                                 }]
 
                                 # axis reductions

--- a/topsf/tasks/plotting.py
+++ b/topsf/tasks/plotting.py
@@ -46,7 +46,9 @@ class PlotVariables1D(
 
         category_inst = self.config_inst.get_category(self.branch_data.category)
         leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
-        process_insts = list(map(self.config_inst.get_process, self.processes))
+
+        for i, config_inst in enumerate(self.config_insts):
+            process_insts = [config_inst.get_process(p) for p in self.processes[i]]
         sub_process_insts = {
             proc: [sub for sub, _, _ in proc.walk_processes(include_self=True)]
             for proc in process_insts
@@ -60,18 +62,23 @@ class PlotVariables1D(
         # https://github.com/columnflow/columnflow/blob/master/columnflow/tasks/plotting.py#L165
         hists: dict[od.Config, dict[od.Process, hist.Hist]] = {}
         with self.publish_step(message):
-            for dataset, inp in self.input().items():
-                dataset_inst = self.config_inst.get_dataset(dataset)
-                h_in = inp["collection"][0]["hists"].targets[self.branch_data.variable].load(formatter="pickle")
+            for i, config_inst in enumerate(self.config_insts):
+                # histogram data per process
+                hists_config = {}
+                for config, ds_inp in self.input().items():
+                    if config_inst.name == config:
+                        for dataset, inp in ds_inp.items():
+                            dataset_inst = config_inst.get_dataset(dataset)
+                            h_in = inp["collection"][0]["hists"].targets[self.branch_data.variable].load(formatter="pickle")
 
-                # loop and extract one histogram per process
-                for process_inst in process_insts:
-                    # skip when the dataset is already known to not contain any sub process
-                    if not any(map(dataset_inst.has_process, sub_process_insts[process_inst])):
-                        continue
+                            # loop and extract one histogram per process
+                            for process_inst in process_insts:
+                                # skip when the dataset is already known to not contain any sub process
+                                if not any(map(dataset_inst.has_process, sub_process_insts[process_inst])):
+                                    continue
 
-                    # work on a copy
-                    h = h_in.copy()
+                                # work on a copy
+                                h = h_in.copy()
 
                                 # axis selections
                                 h = h[{
@@ -92,14 +99,20 @@ class PlotVariables1D(
                                     ]
                                 }]
 
-                    # axis reductions
-                    h = h[{"process": sum, "category": sum}]
+                                # axis reductions
+                                h = h[{"process": sum, "category": sum}]
 
-                    # add the histogram
-                    if process_inst in hists:
-                        hists[process_inst] += h
-                    else:
-                        hists[process_inst] = h
+                                # add the histogram
+                                if process_inst in hists_config:
+                                    hists_config[process_inst] += h
+                                else:
+                                    hists_config[process_inst] = h
+                        hists[config_inst] = {
+                            proc_inst: hists_config[proc_inst]
+                            for proc_inst in sorted(
+                                hists_config.keys(), key=list(config_process_map[config_inst].keys()).index,
+                            )
+                        }
 
             # there should be hists to plot
             if not hists:
@@ -109,22 +122,45 @@ class PlotVariables1D(
                     "  - selected --processes did not match any value on the process axis of the input histogram",
                 )
 
+            # merge configs if multiconfig
+            if len(self.config_insts) != 1:
+                process_memory = {}
+                merged_hists = {}
+                for _hists in hists.values():
+                    for process_inst, h in _hists.items():
+                        if process_inst.id in merged_hists:
+                            merged_hists[process_inst.id] += h
+                        else:
+                            merged_hists[process_inst.id] = h
+                            process_memory[process_inst.id] = process_inst
+
+                process_insts = list(process_memory.values())
+                hists = {process_memory[process_id]: h for process_id, h in merged_hists.items()}
+            else:
+                hists = hists[self.config_inst]
+                process_insts = list(hists.keys())
+
             # sort hists by process order
             hists = OrderedDict(
                 (process_inst.copy_shallow(), hists[process_inst])
                 for process_inst in sorted(hists, key=process_insts.index)
             )
 
-            # call the plot function
-            fig, _ = self.call_plot_func(
-                self.plot_function,
-                hists=hists,
-                config_inst=self.config_inst,
-                category_inst=category_inst.copy_shallow(),
-                variable_insts=[var_inst.copy_shallow() for var_inst in variable_insts],
-                pretty_legend=self.pretty_legend,
-                **self.get_plot_parameters(),
-            )
+            # temporarily use a merged luminostiy value, assigned to the first config
+            config_inst = self.config_insts[0]
+            lumi = sum([_config_inst.x.luminosity for _config_inst in self.config_insts])
+            with law.util.patch_object(config_inst.x, "luminosity", lumi):
+                # call the plot function
+                fig, _ = self.call_plot_func(
+                    self.plot_function,
+                    hists=hists,
+                    config_inst=config_inst,
+                    category_inst=category_inst.copy_shallow(),
+                    variable_insts=[var_inst.copy_shallow() for var_inst in variable_insts],
+                    shift_insts=plot_shifts,
+                    pretty_legend=self.pretty_legend,
+                    **self.get_plot_parameters(),
+                )
 
             # save the plot
             for outp in self.output()["plots"]:

--- a/topsf/tasks/wp/efficiency.py
+++ b/topsf/tasks/wp/efficiency.py
@@ -31,15 +31,15 @@ class EfficiencyVariablesMixin(VariablesMixin):
     )
 
     @classmethod
-    def resolve_param_values(cls, params):
+    def resolve_param_values_post_init(cls, params):
         """
         Resolve `signal_variable` and `binning_variables` and set `variables` param
         to be passed to dependent histogram task.
         """
-        params = super().resolve_param_values(params)
+        params = super().resolve_param_values_post_init(params)
 
         # no-op if config is not set
-        if "config_inst" not in params:
+        if "config_insts" not in params:
             return params
 
         # required parameters not present, do nothing
@@ -51,7 +51,7 @@ class EfficiencyVariablesMixin(VariablesMixin):
             return params
 
         # get configuration instance
-        config_inst = params["config_inst"]
+        config_inst = params["config_insts"][0]
 
         # handle binning variables
         for var_name in list(params["binning_variables"]):

--- a/topsf/tasks/wp/efficiency.py
+++ b/topsf/tasks/wp/efficiency.py
@@ -6,7 +6,6 @@ for WP derivation.
 
 import luigi
 import law
-from collections import OrderedDict
 
 from columnflow.util import dict_add_strict, maybe_import
 from columnflow.tasks.framework.base import Requirements
@@ -203,7 +202,7 @@ class PlotEfficiencyBase(
                             # skip when the dataset does not contain any leaf process
                             if not any(map(dataset_inst.has_process, leaf_process_insts)):
                                 continue
-                            h_in = inp["collection"][0]["hists"].targets[self.branch_data.variable].load(formatter="pickle")
+                            h_in = inp["collection"][0]["hists"].targets[self.branch_data.variable].load(formatter="pickle")  # noqa: E501
 
                             # work on a copy
                             h = h_in.copy()
@@ -237,7 +236,7 @@ class PlotEfficiencyBase(
                                 hists_config[hists_key] += h
                             else:
                                 hists_config[hists_key] = h
-                        for key in ['signal', 'background']:
+                        for key in ["signal", "background"]:
                             try:
                                 hists[config_inst][key] = hists_config[key]
                             except KeyError:
@@ -264,11 +263,9 @@ class PlotEfficiencyBase(
                             merged_hists[plot_mode] = h
                             plot_mode_memory[plot_mode] = plot_mode
 
-                plot_modes = list(plot_mode_memory.values())
                 hists = {plot_mode_memory[plot_mode]: h for plot_mode, h in merged_hists.items()}
             else:
                 hists = hists[self.config_inst]
-                plot_modes = list(hists.keys())
 
             # apply binning variables and ranges to histograms,
             # keeping track of total values

--- a/topsf/tasks/wp/efficiency.py
+++ b/topsf/tasks/wp/efficiency.py
@@ -201,27 +201,27 @@ class PlotEfficiencyBase(
 
                     h_in = inp["collection"][0]["hists"].targets[self.branch_data.variable].load(formatter="pickle")
 
-                    # work on a copy
-                    h = h_in.copy()
+                            # work on a copy
+                            h = h_in.copy()
 
-                    # axis selections
-                    h = h[{
-                        "process": [
-                            hist.loc(p.name)
-                            for p in leaf_process_insts
-                            if p.name in h.axes["process"]
-                        ],
-                        "category": [
-                            hist.loc(c.name)
-                            for c in leaf_category_insts
-                            if c.name in h.axes["category"]
-                        ],
-                        "shift": [
-                            hist.loc(s.name)
-                            for s in plot_shifts
-                            if s.name in h.axes["shift"]
-                        ],
-                    }]
+                            # axis selections
+                            h = h[{
+                                "process": [
+                                    hist.loc(p.name)
+                                    for p in leaf_process_insts
+                                    if p.name in h.axes["process"]
+                                ],
+                                "category": [
+                                    hist.loc(c.name)
+                                    for c in leaf_category_insts
+                                    if c.name in h.axes["category"]
+                                ],
+                                "shift": [
+                                    hist.loc(s.name)
+                                    for s in plot_shifts
+                                    if s.name in h.axes["shift"]
+                                ],
+                            }]
 
                     # axis reductions
                     assert len(h.axes["shift"]) == 1, f"expected exactly one shift axis, got: {h.axes['shift']}"
@@ -268,6 +268,7 @@ class PlotEfficiencyBase(
                 hists[key] = hists[key][sel_hist]
 
             # post-process histograms
+            # FIXME: what does this do?
             hists = self.process_hists(hists)
 
             # call the plot function


### PR DESCRIPTION
This PR contains the changes in order to adapt to the changes introduced by the long overdue columnflow update. It introduces the functionality to support multiple configs necessary to process multiple data taking eras at once. In addition, updating columnflow reduces scheduling and processing times significantly leading to a much quicker turnaround time.

The tasks ```topsf.PlotEfficiency``` and ```topsf.PlotROCCurve``` for the working point analysis as well as the ```topsf.PlotVariables1D``` for the scale factor analysis have been fixed and tested in the current commits and work for single and multiple configs, tested with both 2022 data taking eras. The commands used for testing can be found at the end of this text. The working point analysis is therefore in a fully functional state. For the scale factor analysis, the task yet to be fixed is ```topsf.CreateDatacards``` which requires some changes to the task itself, but also to the inference model to adapt to the columnflow updates.

I will add to this PR when this task is fixed. I don't expect the other changes to interfere with the fixes I've made so far which means a review of the current state can begin.

The tasks calling Combine commands will not be fixed at the current state as there are other issues with the sandboxes which are beyond the scope of this PR. These are to be fixed at a later stage. 

```
law run topsf.PlotROCCurve --signal-tag is_ttbar --version test_updates_250704_v1 --analysis topsf.config.run3.analysis_wp.analysis_wp --configs run3_wp_2022_postEE_nano_v12_limited --datasets tt_fh_powheg,qcd_mu_pt470to600_pythia --processes qcd,tt --selector wp --efficiency-variable fatjet_tau32 --binning-variables fatjet_pt,min=400:fatjet_msoftdrop_for_wp,min=105,max=210,flow --plot-suffix new_wp_definitions__msoftdrop --producers weights --file-types pdf,png --workflow local --remove-output 0,a,y --cms-label simpw
```
```
law run topsf.PlotVariables1D --variables probejet_msoftdrop_inf_rebin --version test_updates_250704_v1 --analysis topsf.config.run3.analysis_sf.analysis_sf --configs run3_sf_2022_preEE_nano_v12_limited --datasets tt_sl_powheg,st_tchannel_t_4f_powheg,dy_m4to50_ht800to1500_madgraph,ww_pythia,w_lnu_mlnu0to120_ht800to1500_madgraph,qcd_mu_pt470to600_pythia,data_mu_c --calibrator default --selector default --processes data,vx,st_bkg,st_0o1q,st_2q,st_3q,tt_bkg,tt_0o1q,tt_2q,tt_3q,mj --producers features,weights --categories 1m,1e --cms-label pw --pretty-legend True --workflow local --remove-output 0,a,y --local-scheduler False --workers 3 --file-types pdf,png
```